### PR TITLE
Replace opengda.org with alfred.diamond.ac.uk in Developing DAWN

### DIFF
--- a/_pages/03_using-dawn.md
+++ b/_pages/03_using-dawn.md
@@ -9,9 +9,9 @@ All our full detail raw videos are available on the following URL:
 
 See the dawn [youtube channel](http://www.youtube.com/user/DAWNScience) for a complete list of dawn videos.
 
-The Diamond Light Source DAWN training can be found [here.](http://confluence.diamond.ac.uk/display/DT/DAWN+Training+Home)
+The Diamond Light Source DAWN training can be found [here.](https://confluence.diamond.ac.uk/display/DT/DAWN+Training+Home)
 
-Tutorials for 2D Powder Diffraction/Small Angle X-ray Scattering (SAXS) calibration and reduction can be found [here.](http://confluence.diamond.ac.uk/display/DT/2D+Powder+Calibration+and+Reduction+Tutorial)
+Tutorials for 2D Powder Diffraction/Small Angle X-ray Scattering (SAXS) calibration and reduction can be found [here.](https://confluence.diamond.ac.uk/display/DT/2D+Powder+Calibration+and+Reduction+Tutorial)
 
 Here are some video tutorials showing DAWN main features:
 

--- a/_pages/04.04_contributing.md
+++ b/_pages/04.04_contributing.md
@@ -43,7 +43,7 @@ The license of contributed code should be EPL or Apache. LGPL or GPL code is not
 
 ## Testing your code
 
-Diamond make a nightly build of Dawn (‘vanilla’) if you would like to test new contributions to Dawn. This is available at [http://opengda.org/DawnVanilla/master/downloads/builds-snapshot/](http://opengda.org/DawnVanilla/master/downloads/builds-snapshot/) for the Diamond specific build of Dawn.
+Diamond make a nightly build of Dawn if you would like to test new contributions to Dawn. This is available at [https://alfred.diamond.ac.uk/DawnDiamond/master/downloads/builds-snapshot/](https://alfred.diamond.ac.uk/DawnDiamond/master/downloads/builds-snapshot/) for the Diamond specific build of Dawn.
 
 Help may be given by Diamond and other member institutions on creating a build of Dawn - for instance, the files for a Buckminster build and an explanation of how to get started. Ongoing support of external builds of Dawn is not an obligation of members.
 

--- a/_pages/04.06_collaborate.md
+++ b/_pages/04.06_collaborate.md
@@ -25,7 +25,7 @@ Below are the links to the DAWN bug-tracking, Google Code and GitHub pages.
 
 There is a [reference card](https://alfred.diamond.ac.uk/documentation/manuals/Reference_Card/trunk/reference.html) available for using buckminster to check out and build the source code.
 
-[**DAWN Bug tracking**](http://jira.diamond.ac.uk/browse/DAWNSCI)  
+[**DAWN Bug tracking**](https://jira.diamond.ac.uk/browse/DAWNSCI)  
   
 [**DAWN Google Wiki**](http://code.google.com/a/eclipselabs.org/p/dawn/w/list)
 

--- a/_pages/04.06_collaborate.md
+++ b/_pages/04.06_collaborate.md
@@ -23,7 +23,7 @@ When you contribute code to DAWN you agree to do so under the following conditio
 
 Below are the links to the DAWN bug-tracking, Google Code and GitHub pages.  
 
-There is a [reference card](http://opengda.org/documentation/manuals/Reference_Card/trunk/reference.html) available for using buckminster to check out and build the source code.
+There is a [reference card](https://alfred.diamond.ac.uk/documentation/manuals/Reference_Card/trunk/reference.html) available for using buckminster to check out and build the source code.
 
 [**DAWN Bug tracking**](http://jira.diamond.ac.uk/browse/DAWNSCI)  
   

--- a/_pages/04.07.03_raptor.md
+++ b/_pages/04.07.03_raptor.md
@@ -188,7 +188,7 @@ any plot may be smoothed
 
 ### []()Harmonizing DExplore and Data Browsing perspective
 
-A ticket has already been created for this: http://jira.diamond.ac.uk/browse/DAWNSCI for those with access.
+A ticket has already been created for this: https://jira.diamond.ac.uk/browse/DAWNSCI for those with access.
 
 ### []()Pydev Actor *
 
@@ -339,13 +339,13 @@ be created. The tools will require the use to zoom until no-downsampling
  is done so that individual pixels can be edited without the use of 
 regions which are less precise.
 
-http://jira.diamond.ac.uk/browse/SCI-384
+https://jira.diamond.ac.uk/browse/SCI-384
 
-http://jira.diamond.ac.uk/browse/SCATTER-6
+https://jira.diamond.ac.uk/browse/SCATTER-6
 
-http://jira.diamond.ac.uk/browse/DAWNSCI-183
+https://jira.diamond.ac.uk/browse/DAWNSCI-183
 
-http://jira.diamond.ac.uk/browse/DAWNSCI-184
+https://jira.diamond.ac.uk/browse/DAWNSCI-184
 
             **Estimate: 6d   Status:
 New Feature     ****   ****Collaborator: **_Diamond_

--- a/_pages/04.07.04_harrier.md
+++ b/_pages/04.07.04_harrier.md
@@ -126,7 +126,7 @@ As a developer you can easily add a file loader but users working inside DAWN ca
 
 - **Plot Function**
 
-See [http://jira.diamond.ac.uk/browse/SCI-1421](http://jira.diamond.ac.uk/browse/SCI-1421)
+See [https://jira.diamond.ac.uk/browse/SCI-1421](https://jira.diamond.ac.uk/browse/SCI-1421)
 
 Plot function should:
 


### PR DESCRIPTION
@mwebber @jacobfilik @jamesmudd

There are a couple of remaining references to now defunct opengda.org urls in posts of old DAWN releases, but thought it was safe to keep those.