### PR TITLE
Add container

### DIFF
--- a/.github/workflows/push-container.yaml
+++ b/.github/workflows/push-container.yaml
@@ -1,0 +1,42 @@
+name: Build and publish image
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Build and push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create tags for publishing image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/dawn
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push image to GitHub Packages
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./releng/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/releng/Dockerfile
+++ b/releng/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:latest
+RUN apt-get update && apt-get install -y unzip wget
+RUN mkdir /dawn_workspace
+WORKDIR /dawn_workspace
+
+RUN wget -q -O- https://api.github.com/repos/DawnScience/dawn-website/releases/latest | grep -wo "https.*linux.x86_64.zip" | wget -qi-
+RUN unzip -q "*.zip"


### PR DESCRIPTION
Remade version of #51 to target `master`

@PeterC-DLS I've made all your suggested changes except for the removal of L33 `type=raw,value=latest` - I think it is needed for the package to be published when running the workflow manually. See [here for a run without it](https://github.com/JamesDoingStuff/dawn-website/actions/runs/22065511058/workflow) that failed.