### PR TITLE
Test run container workflow

### DIFF
--- a/.github/workflows/push_container.yaml
+++ b/.github/workflows/push_container.yaml
@@ -1,0 +1,43 @@
+name: Build and publish image
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  push_to_registry:
+    name: Build and push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create tags for publishing image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/dawn
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push image to GitHub Packages
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./releng/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The purpose of this PR is to try and trigger the workflow included herewith so that the workflow will be visible in the repo's Actions tab - once this is the case, I should be able to run it directly on the `master` branch and this PR will be closed. Until then however, the actions on `master` are inaccessible, as `workflow_dispatch` only works on the default branch. (See https://www.github.com/orgs/community/discussions/25746#discussioncomment-3249056)
